### PR TITLE
Fix infinite loop on MonotoneCurve

### DIFF
--- a/lib/src/line/curves.dart
+++ b/lib/src/line/curves.dart
@@ -105,6 +105,8 @@ class MonotoneCurve implements LineCurve {
     final lastX = points.last.dx;
 
     final step = (lastX - firstX) / count;
+    
+    if (step == 0) return points;
 
     final result = <Offset>[];
     for (var x = firstX; x <= lastX; x += step) {


### PR DESCRIPTION
When calling MonotoneCurve with points that share the X coordinate, step is 0, causing an endless loop